### PR TITLE
packaging: add back oVirt CLI Entry point

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,9 @@ ovirtlago =
 
 [entry_points]
 
+lago.plugins.cli =
+    ovirt=ovirtlago.cmd:OvirtCLI
+
 lago.plugins.vm =
     default=lago.vm:DefaultVM
     ovirt-node=ovirtlago.virt:NodeVM


### PR DESCRIPTION
Was missing.

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>