### PR TITLE
Automation: Remove duplicate packages from mock *.packages

### DIFF
--- a/automation/check-patch.packages
+++ b/automation/check-patch.packages
@@ -5,6 +5,4 @@ git
 grubby
 python2-devel
 python2-dulwich
-python2-tox
-python2-virtualenv
 python-pip

--- a/automation/check-patch.packages.el7
+++ b/automation/check-patch.packages.el7
@@ -3,7 +3,5 @@ git
 python2-devel
 python-dulwich
 python-pip
-python-tox
-python-virtualenv
 yum
 yum-utils


### PR DESCRIPTION
1. virtualenv, and tox are being installed before running the
   tests (using pip).
2. For some reason when installing tox from rpm, entry points aren't
   created, and then the job failed on 'tox: Command not found'. This
   patch will ensure that tox is always installed from PyPi.

Signed-off-by: gbenhaim <galbh2@gmail.com>