### PR TITLE
docs: Fix docs creation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,14 @@ subprocess.call([
     'changelog',
 ])
 shutil.move('../ChangeLog', '_static/ChangeLog.txt')
+
+# Mock all the modules that are included by lago, so autoimport works as
+# expected with no need to download them (some are not in pip even)
+autodoc_mock_imports = [
+    'lago',
+    'ovirtsdk',
+]
+
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.todo',

--- a/ovirtlago/utils.py
+++ b/ovirtlago/utils.py
@@ -120,7 +120,8 @@ def get_data_file(basename):
     )
 
 
-def available_sdks(modules=sys.modules):
+def available_sdks(modules=None):
+    modules = modules or sys.modules
     res = []
     if 'ovirtsdk' in modules:
         res.append('3')
@@ -129,7 +130,9 @@ def available_sdks(modules=sys.modules):
     return res
 
 
-def require_sdk(version, modules=sys.modules):
+def require_sdk(version, modules=None):
+    modules = modules or sys.modules
+
     def wrap(func):
         @functools.wraps(func)
         def wrapped_func(*args, **kwargs):


### PR DESCRIPTION
1. Mocking dependencies: lago, ovirtsdk.
2. Remove 'sys.modules' from function signature (otherwise the entire
   module list will show up in the docs).

Signed-off-by: gbenhaim <galbh2@gmail.com>