### PR TITLE
docs: Fix docs (part of 0005f90)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,10 +53,7 @@ shutil.move('../ChangeLog', '_static/ChangeLog.txt')
 
 # Mock all the modules that are included by lago, so autoimport works as
 # expected with no need to download them (some are not in pip even)
-autodoc_mock_imports = [
-    'lago',
-    'ovirtsdk',
-]
+autodoc_mock_imports = ['lago', 'ovirtsdk', 'yaml', 'configparser']
 
 extensions = [
     'sphinx.ext.autodoc',

--- a/docs/docs-requires.txt
+++ b/docs/docs-requires.txt
@@ -1,3 +1,3 @@
-sphinx
+sphinx>=1.6
 nose
 dulwich


### PR DESCRIPTION
1. Adding mocks to configparser and yaml.
2. Enforcing sphinx version>=1.6 (which includes bug fixes for emtpy
   toctree and creating mocks for sub-modules).

Signed-off-by: gbenhaim <galbh2@gmail.com>