### PR TITLE
lago ovirt start: Match cluster CPU compatibility

### DIFF
--- a/automation/common.sh
+++ b/automation/common.sh
@@ -33,7 +33,9 @@ die() {
 }
 
 setup_tox() {
-    pip install --upgrade pip setuptools virtualenv tox || return 1
+    for package in "pip" "setuptools" "virtualenv" "tox" ; do
+        pip install --upgrade "$package" || return 1
+    done
 }
 
 build_docs() {

--- a/ovirtlago/cmd.py
+++ b/ovirtlago/cmd.py
@@ -250,6 +250,8 @@ def do_ovirt_start(prefix, with_vms, vms_timeout, **kwargs):
             prefix.virt_env.assert_engine_alive(timeout=3 * 60)
         with LogTask('Waiting for vdsmd status'):
             prefix.virt_env.assert_vdsm_alive(timeout=3 * 60)
+        with LogTask('Updating Clusters CPU'):
+            prefix.virt_env.update_clusters_cpu()
         with LogTask('Activating Engine Hosts'):
             prefix.virt_env.engine_vm().start_all_hosts(timeout=5 * 60)
         if with_vms:


### PR DESCRIPTION
When exporting images and starting them on a different host, Lago will
set the VM's CPU type to libvirt 'host-passthrough' mode by default. This
means that when the VMs start, the CPU type of the host(in oVirt's eyes)
could have changed without it being aware. So this patch ensures the
cluster compatibility level would be matched to the new CPU, if it
changed,  when running 'lago ovirt start'.

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>