### PR TITLE
Download Engine CA certificte

### DIFF
--- a/ovirtlago/constants.py
+++ b/ovirtlago/constants.py
@@ -26,3 +26,4 @@ ANSWER_FILES_DIR = os.path.join(DATA_DIR, 'config', 'answer-files')
 REPO_SERVER_PORT = 8585
 ENGINE_USER = 'admin@internal'
 ENGINE_PASSWORD = '123'
+ENGINE_BASEURL = 'https://{0}/ovirt-engine'


### PR DESCRIPTION
For the time being, we can't use it: we connect to Engine using IP
and the certificate is signed for 'engine'. When we switch from IP
to DNS, it could work, but this should be done in a separate commit.

This will be useful when we wish to use the certificate in some tests
(image upload, OVN API tests, etc.)