### PR TITLE
fail early if no SUITE

### DIFF
--- a/ovirtlago/testlib.py
+++ b/ovirtlago/testlib.py
@@ -47,7 +47,7 @@ def get_test_prefix():
 
 
 def get_prefixed_name(entity_name):
-    suite = os.environ.get('SUITE')
+    suite = os.environ['SUITE']
     return (
         'lago-' + os.path.basename(suite).replace('.', '-') + '-' + entity_name
     )


### PR DESCRIPTION
If for any reason SUITE in not defined in env, we should failure on
KeyError, not on a vague

    AttributeError: 'NoneType' object has no attribute 'rfind'

from the line below.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>