### PR TITLE
Adding IBRS cpus

### DIFF
--- a/ovirtlago/data/ovirt_cpu_map.yaml
+++ b/ovirtlago/data/ovirt_cpu_map.yaml
@@ -8,12 +8,21 @@ Intel:
   Conroe: Intel Conroe Family
   Penryn: Intel Penryn Family
   Nehalem: Intel Nehalem Family
+  Nehalem-IBRS: Intel Nehalem-IBRS Family
   Westmere: Intel Westmere Family
+  Westmere-IBRS: Intel Westmere-IBRS Family
   SandyBridge: Intel SandyBridge Family
+  SandyBridge-IBRS: Intel SandyBridge-IBRS Family
   IvyBridge: Intel SandyBridge Family
+  IvyBridge-IBRS: Intel SandyBridge-IBRS Family
   Haswell-noTSX: Intel Haswell-noTSX Family
+  Haswell-IBRS: Intel Haswell-IBRS Family
+  Haswell-noTSX-IBRS: Intel Haswell-noTSX-IBRS Family
   Haswell: Intel Haswell Family
   Broadwell-noTSX: Intel Broadwell-noTSX Family
+  Broadwell-IBRS: Intel Broadwell-IBRS Family
+  Broadwell-noTSX-IBRS: Intel Broadwell-noTSX-IBRS Family
   Broadwell: Intel Broadwell-noTSX Family
   Skylake: Intel Skylake Family
+  Skylake-IBRS: Intel Skylake-IBRS Family
   Skylake-Client: Intel Skylake Family


### PR DESCRIPTION
Adding IBRS cpus to the mapping.
Based on https://github.com/lago-project/lago-ost-plugin/pull/31, the only change is that I've added a mapping for `IvyBridge-IBRS`