### PR TITLE
reposetup: Allow to create multiple internal repos

### DIFF
--- a/ovirtlago/cmd.py
+++ b/ovirtlago/cmd.py
@@ -140,11 +140,17 @@ def do_ovirt_runtest(prefix, test_file, **kwargs):
     action='store',
     default=None,
 )
+@cli_plugin_add_argument(
+    '--repo-name',
+    help='The name of the repo that will be created in the prefix.',
+    action='store',
+    default='default',
+)
 @in_ovirt_prefix
 @with_logging
 def do_ovirt_reposetup(
     prefix, rpm_repo, reposync_yum_config, repoman_config, skip_sync,
-    custom_sources, **kwargs
+    custom_sources, repo_name, **kwargs
 ):
 
     if rpm_repo is None:
@@ -156,6 +162,7 @@ def do_ovirt_reposetup(
         skip_sync=skip_sync,
         custom_sources=custom_sources,
         repoman_config=repoman_config,
+        sub_repo_name=repo_name
     )
 
 

--- a/ovirtlago/prefix.py
+++ b/ovirtlago/prefix.py
@@ -64,6 +64,7 @@ class OvirtPrefix(Prefix):
         repoman_config,
         custom_sources=None,
         projects_list=None,
+        sub_repo_name='default'
     ):
 
         if not projects_list:
@@ -92,8 +93,12 @@ class OvirtPrefix(Prefix):
                 ],
             )
 
+        internal_repo_path = os.path.join(
+            self.paths.internal_repo(), sub_repo_name
+        )
+
         reposetup.merge(
-            output_dir=self.paths.internal_repo(),
+            output_dir=internal_repo_path,
             sources=custom_sources + rpm_dirs,
             repoman_config=repoman_config,
         )
@@ -105,7 +110,8 @@ class OvirtPrefix(Prefix):
         reposync_yum_config=None,
         repoman_config=None,
         skip_sync=False,
-        custom_sources=None
+        custom_sources=None,
+        sub_repo_name='default'
     ):
         # Detect distros from template metadata
         engine_dists = [self.virt_env.engine_vm().distro()] \
@@ -163,6 +169,7 @@ class OvirtPrefix(Prefix):
             repo_names=repos,
             repoman_config=repoman_config,
             custom_sources=custom_sources or [],
+            sub_repo_name=sub_repo_name
         )
         self.save()
 


### PR DESCRIPTION
This change introduce a new flag (--repo-name) to the reposetup command.
The flag indicates the name of the internal repo to create.
Multiple internal repos can be created, all of them will be available
with "lago ovirt serve".

The following illustrates the directory structure of multiple internal
repos:
```
.lago/default/internal_repo/
├── default
│   └── el7
│       └── repodata
└── my-custom-repo
    └── el7
        └── repodata

```

Signed-off-by: gbenhaim <galbh2@gmail.com>