### PR TITLE
Wrapper for system service

### DIFF
--- a/ovirtlago/testlib.py
+++ b/ovirtlago/testlib.py
@@ -81,6 +81,18 @@ def with_ovirt_api4(func):
     return wrapper
 
 
+def with_ovirt_api4_service(func):
+    @functools.wraps(func)
+    @with_ovirt_prefix
+    def wrapper(prefix, *args, **kwargs):
+        return func(
+            prefix.virt_env.engine_vm().get_api_v4_system_service(), *args,
+            **kwargs
+        )
+
+    return wrapper
+
+
 def _vms_capable(vms, caps):
     caps = set(caps)
 

--- a/ovirtlago/virt.py
+++ b/ovirtlago/virt.py
@@ -340,6 +340,10 @@ class EngineVM(lago.vm.DefaultVM):
                 raise RuntimeError('Could not connect to engine')
         return self._api_v4
 
+    def get_api_v4_system_service(self):
+        api = self.get_api_v4(False)
+        return api.system_service()
+
     def add_iso(self, path):
         iso_name = os.path.basename(path)
         self.copy_to(path, '.')


### PR DESCRIPTION
Add a decorator to get the oVirt API system_service() directly.
    
    Just reduces code, as many times the decorator to get the API
    is actually to get the system_service() from it.
