### PR TITLE
Internal repo HTTP server improvements

### DIFF
--- a/ovirtlago/reposetup.py
+++ b/ovirtlago/reposetup.py
@@ -32,7 +32,7 @@ from lago.utils import (
     LockFile,
 )
 
-from . import utils
+from ovirtlago import server
 
 LOGGER = logging.getLogger(__name__)
 LogTask = functools.partial(log_utils.LogTask, logger=LOGGER)
@@ -108,7 +108,7 @@ def merge(output_dir, sources, repoman_config=None):
 def with_repo_server(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        with utils.repo_server_context(args[0]):
+        with server.repo_server_context(args[0]):
             return func(*args, **kwargs)
 
     return wrapper

--- a/ovirtlago/reposetup.py
+++ b/ovirtlago/reposetup.py
@@ -32,7 +32,7 @@ from lago.utils import (
     LockFile,
 )
 
-from ovirtlago import server
+from ovirtlago import constants, server
 
 LOGGER = logging.getLogger(__name__)
 LogTask = functools.partial(log_utils.LogTask, logger=LOGGER)
@@ -106,9 +106,24 @@ def merge(output_dir, sources, repoman_config=None):
 
 
 def with_repo_server(func):
+    """
+    Context manger that starts an http server which serves
+    the prefix's internal_repo. The server will listen on the
+    management network's IP, and on port `constans.REPO_SERVER_PORT`
+
+    Args:
+        The first argument to the wrapped func should be a
+            `lago.prefix.Prefix` instance.
+    """
+
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        with server.repo_server_context(args[0]):
+        prefix = args[0]
+        with server.repo_server_context(
+            gw_ip=prefix.virt_env.get_net().gw(),
+            port=constants.REPO_SERVER_PORT,
+            root_dir=prefix.paths.internal_repo(),
+        ):
             return func(*args, **kwargs)
 
     return wrapper

--- a/ovirtlago/server.py
+++ b/ovirtlago/server.py
@@ -1,0 +1,103 @@
+#
+# Copyright 2014-2017 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+#
+# Refer to the README and COPYING files for full details of the license
+#
+import BaseHTTPServer
+import contextlib
+import os
+import threading
+from SimpleHTTPServer import SimpleHTTPRequestHandler
+
+from . import constants
+
+
+def generate_request_handler(root_dir):
+    """
+    Factory for _BetterHTTPRequestHandler classes
+
+    Args:
+        root_dir (path): Path to the dir to serve
+
+    Returns:
+        _BetterHTTPRequestHandler: A ready to be used improved http request
+            handler
+    """
+
+    class _BetterHTTPRequestHandler(SimpleHTTPRequestHandler):
+        __root_dir = root_dir
+        _len_cwd = len(os.getcwd())
+
+        def translate_path(self, path):
+            return os.path.join(
+                self.__root_dir,
+                SimpleHTTPRequestHandler.translate_path(
+                    self, path
+                )[self._len_cwd:].lstrip('/')
+            )
+
+        def log_message(self, *args, **kwargs):
+            pass
+
+    return _BetterHTTPRequestHandler
+
+
+def _create_http_server(listen_ip, listen_port, root_dir):
+    """
+    Starts an http server with an improved request handler
+
+    Args:
+        listen_ip (str): Ip to listen on
+        port (int): Port to register on
+        root_dir (str): path to the directory to serve
+
+    Returns:
+        BaseHTTPServer: instance of the http server, already running on a
+            thread
+    """
+    server = BaseHTTPServer.HTTPServer(
+        (listen_ip, listen_port),
+        generate_request_handler(root_dir),
+    )
+    threading.Thread(target=server.serve_forever).start()
+    return server
+
+
+@contextlib.contextmanager
+def repo_server_context(prefix):
+    """
+    Context manager that starts an http server that serves the given prefix's
+    yum repository. Will listen on :class:`constants.REPO_SERVER_PORT` and on
+    the first network defined in the previx virt config
+
+    Args:
+        prefix(ovirtlago.prefix.OvirtPrefix): prefix to start the server for
+
+    Returns:
+        None
+    """
+    gw_ip = prefix.virt_env.get_net().gw()
+    port = constants.REPO_SERVER_PORT
+    server = _create_http_server(
+        listen_ip=gw_ip,
+        listen_port=port,
+        root_dir=prefix.paths.internal_repo(),
+    )
+    try:
+        yield
+    finally:
+        server.shutdown()

--- a/ovirtlago/server.py
+++ b/ovirtlago/server.py
@@ -23,8 +23,6 @@ import os
 import threading
 from SimpleHTTPServer import SimpleHTTPRequestHandler
 
-from . import constants
-
 
 def generate_request_handler(root_dir):
     """
@@ -78,24 +76,21 @@ def _create_http_server(listen_ip, listen_port, root_dir):
 
 
 @contextlib.contextmanager
-def repo_server_context(prefix):
+def repo_server_context(gw_ip, port, root_dir):
     """
-    Context manager that starts an http server that serves the given prefix's
-    yum repository. Will listen on :class:`constants.REPO_SERVER_PORT` and on
-    the first network defined in the previx virt config
+    Context manager that starts a generic http server that serves `root_dir`,
+    and listens on `gw_ip`:`port`.
 
     Args:
-        prefix(ovirtlago.prefix.OvirtPrefix): prefix to start the server for
-
-    Returns:
-        None
+        gw_ip(str): IP to listen on
+        port(int): Port to listen on
+        root_dir(str): The root directory that will be served.
     """
-    gw_ip = prefix.virt_env.get_net().gw()
-    port = constants.REPO_SERVER_PORT
+
     server = _create_http_server(
         listen_ip=gw_ip,
         listen_port=port,
-        root_dir=prefix.paths.internal_repo(),
+        root_dir=root_dir,
     )
     try:
         yield


### PR DESCRIPTION
#### Move http server logic to server.py
#### Organize HTTP server context managers

- `repo_server_context` is a context manager that starts an HTTP server
   with a given IP, port, and root directory.

- `with_repo_server` is a context manager that uses the former CM
   for serving the prefix's internal repo.

#### Add multi-threaded http server with custom logging
Signed-off-by: gbenhaim <galbh2@gmail.com>


