### PR TITLE
Catch exceptions when collecting logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,12 @@ build:
 check: check-local
 
 check-local:
+	@# Check SSL backend for pycurl
+	@if curl-config --configure | grep -q '\-\-with\-nss'; then \
+		export PYCURL_SSL_LIBRARY=nss; \
+	else \
+		export PYCURL_SSL_LIBRARY=openssl; \
+	fi; \
 	tox -r -e py27
 
 dist: ${TARBALL_DIST_LOCATION}
@@ -89,3 +95,4 @@ clean:
 
 docs:
 	tox -r -e docs
+

--- a/automation/check-patch.packages
+++ b/automation/check-patch.packages
@@ -6,3 +6,7 @@ grubby
 python2-devel
 python2-dulwich
 python-pip
+libcurl-devel
+libvirt-devel
+openssl-devel
+libxml2-devel

--- a/automation/check-patch.packages.el7
+++ b/automation/check-patch.packages.el7
@@ -5,3 +5,8 @@ python-dulwich
 python-pip
 yum
 yum-utils
+libcurl-devel
+libvirt-devel
+openssl-devel
+libxml2-devel
+

--- a/ovirtlago/testlib.py
+++ b/ovirtlago/testlib.py
@@ -26,7 +26,8 @@ import unittest.case
 import nose.plugins
 from nose.plugins.skip import SkipTest
 
-from lago import (utils, log_utils, cmd as lago_cmd)
+from lago import (utils, log_utils)
+from lago.plugins.vm import (ExtractPathError, ExtractPathNoPathError)
 
 import ovirtlago
 
@@ -167,11 +168,13 @@ class LogCollectorPlugin(nose.plugins.Plugin):
     def _addFault(self, test, err):
         suffix = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
         test_name = '%s-%s' % (test.id(), suffix)
-        lago_cmd.do_collect(
-            prefix=self._prefix,
-            output=self._prefix.paths.test_logs(test_name),
-            no_skip=False
-        )
+
+        try:
+            self._prefix.collect_artifacts(
+                self._prefix.paths.test_logs(test_name), False
+            )
+        except (ExtractPathError, ExtractPathNoPathError) as e:
+            LOGGER.debug(e, exc_info=True)
 
 
 class TaskLogNosePlugin(nose.plugins.Plugin):

--- a/test-requires.txt
+++ b/test-requires.txt
@@ -1,3 +1,4 @@
+pycurl==7.43.0.1
 pytest
 nose
 configparser
@@ -8,3 +9,7 @@ pytest-cov
 flake8
 dulwich
 enum
+lago
+mock
+ovirt-engine-sdk-python
+ovirt-engine-sdk===3.2.0.11-SNAPSHOT

--- a/test-requires.txt
+++ b/test-requires.txt
@@ -1,4 +1,3 @@
-pycurl==7.43.0.1
 pytest
 nose
 configparser

--- a/tests/unit/ovirtlago/test_ovirtlago_utils.py
+++ b/tests/unit/ovirtlago/test_ovirtlago_utils.py
@@ -42,8 +42,12 @@ class TestUtilsOvirtSDKs(object):
 
     @pytest.mark.parametrize(
         ('modules', 'version'), [
-            (['ovirtsdk4'], '4'), (['ovirtsdk'], '3'),
-            (['ovirtsdk', 'dummy'], '3'), (['ovirtsdk', 'ovirtsdk4'], '3')
+            (['ovirtsdk4'], '4'),
+            (['ovirtsdk'], '3'),
+            (['ovirtsdk', 'dummy'], '3'),
+            (['ovirtsdk', 'ovirtsdk4'], '3'),
+            ([], '3'),
+            ([], '4'),
         ]
     )
     def test_require_sdk(self, modules, version):
@@ -58,7 +62,6 @@ class TestUtilsOvirtSDKs(object):
             (['ovirtsdk4'], '3'),
             (['ovirtsdk'], '4'),
             (['ovirtsdk', 'dummy'], '4'),
-            ({}, '4'),
         ]
     )
     def test_require_sdk_mismatch(self, modules, version):

--- a/tests/unit/ovirtlago/test_runtest.py
+++ b/tests/unit/ovirtlago/test_runtest.py
@@ -1,0 +1,33 @@
+from collections import namedtuple
+import pytest
+from mock import MagicMock, patch
+
+from lago.plugins.vm import (ExtractPathError, ExtractPathNoPathError)
+
+from ovirtlago import (testlib, prefix)
+
+DummyTest = namedtuple('DummyTest', ['id'])
+
+
+@pytest.fixture
+def mock_prefix():
+    return MagicMock(spec=prefix.OvirtPrefix, name='mock_prefix')
+
+
+@pytest.fixture
+def dummy_test():
+    return DummyTest(id=lambda: 123)
+
+
+@pytest.mark.parametrize('exc', [ExtractPathError, ExtractPathNoPathError])
+@patch('ovirtlago.testlib.LOGGER')
+def test_log_collection_should_ignore_extract_path_error(
+    mock_logger, mock_prefix, dummy_test, exc
+):
+    exc_instance = exc()
+    mock_prefix.collect_artifacts.side_effect = exc_instance
+    log_collector = testlib.LogCollectorPlugin(mock_prefix)
+    log_collector._addFault(dummy_test, None)
+
+    mock_prefix.collect_artifacts.assert_called_once()
+    mock_logger.debug.assert_called_with(exc_instance, exc_info=True)

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,6 @@ deps =
       -r{toxinidir}/test-requires.txt
 
 whitelist_externals = /bin/bash
-setenv =
-    PYCURL_SSL_LIBRARY=nss
 
 [testenv:docs]
 changedir = docs

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ deps =
       -r{toxinidir}/test-requires.txt
 
 whitelist_externals = /bin/bash
+setenv =
+    PYCURL_SSL_LIBRARY=nss
 
 [testenv:docs]
 changedir = docs


### PR DESCRIPTION
Log collection is triggered by "LogCollectorPlugin" on test failure.
Without this change, if an exception is raised while collecting the
logs from the VMs, the junit.xml report isn't being generated.

Signed-off-by: gbenhaim <galbh2@gmail.com>