### PR TITLE
Lago ost plugin does not need to depend directly on createrepo.

### DIFF
--- a/lago-ovirt.spec.in
+++ b/lago-ovirt.spec.in
@@ -42,7 +42,6 @@ Requires: python-lago >= 0.39
 Requires: python-magic
 Requires: python-nose
 Requires: ovirt-engine-sdk-python >= 3.6.9.1-1
-Requires: createrepo
 Requires: repoman >= 2.0.12
 Requires: yum-utils
 Requires: rpm-build


### PR DESCRIPTION
repoman depends on it (on createrepo_c which is OK).
This allows us to get rid of 'yum' if needed, which allows me to
upgrade to F29!