### PR TITLE
Make tox testenv Python version agnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ check-local:
 	else \
 		export PYCURL_SSL_LIBRARY=openssl; \
 	fi; \
-	tox -r -e py27
+	tox -r -e py
 
 dist: ${TARBALL_DIST_LOCATION}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py27,docs
+envlist = py,docs
 
 
-[testenv:py27]
+[testenv:py]
 commands = {toxinidir}/scripts/check_style.sh
            flake8
            pytest -vvv \


### PR DESCRIPTION
Let's make it work for Python 3 this way.