### PR TITLE
Set +e before running yapf in check_style.sh

### DIFF
--- a/scripts/check_style.sh
+++ b/scripts/check_style.sh
@@ -18,8 +18,7 @@ fi
 yapf --version
 echo "running yapf on the following files:"
 echo "$files"
-# see: https://github.com/google/yapf/issues/325
-# yapf --diff will always exit with '0' as return code
+set +e
 yapf_diff=$(yapf --style .style.yapf --diff --parallel $files)
 
 if [[ -n "${yapf_diff// }" ]]; then


### PR DESCRIPTION
yapf can return with an error code now and the diff wouldn't be
printed if -e was enabled for yapf invocation.