### PR TITLE
Remove direct dependencies on SDK v3

### DIFF
--- a/ovirtlago/virt.py
+++ b/ovirtlago/virt.py
@@ -29,9 +29,6 @@ from lago.config import config as lago_config
 from ovirtlago import utils
 from utils import partial
 
-import ovirtsdk.api
-from ovirtsdk.infrastructure.errors import (RequestError, ConnectionError)
-
 from . import (
     constants,
     testlib,
@@ -284,13 +281,6 @@ class EngineVM(lago.vm.DefaultVM):
         if api_ver == 3:
             if '3' not in available_sdks():
                 raise RuntimeError('oVirt Python SDK v3 not found.')
-            return ovirtsdk.api.API(
-                url=url,
-                username=constants.ENGINE_USER,
-                password=str(self.metadata['ovirt-engine-password']),
-                validate_cert_chain=False,
-                insecure=True,
-            )
         if api_ver == 4:
             if '4' not in available_sdks():
                 raise RuntimeError('oVirt Python SDK v4 not found.')
@@ -318,10 +308,7 @@ class EngineVM(lago.vm.DefaultVM):
                     return True
                 return False
 
-            testlib.assert_true_within_short(
-                get,
-                allowed_exceptions=[RequestError, ConnectionError],
-            )
+            testlib.assert_true_within_short(get)
         except AssertionError:
             raise RuntimeError('Failed to connect to the engine')
 

--- a/tests/unit/ovirtlago/test_ovirtlago_utils.py
+++ b/tests/unit/ovirtlago/test_ovirtlago_utils.py
@@ -25,16 +25,14 @@ from ovirtlago import utils
 
 class TestUtilsOvirtSDKs(object):
     @pytest.mark.parametrize(
-        ('modules'),
-        [(['ovirtsdk4', 'ovirtsdk']), (['ovirtsdk4', 'ovirtsdk', 'dummy'])]
+        ('modules'), [(['ovirtsdk4']), (['ovirtsdk4', 'dummy'])]
     )
     def test_available_all(self, modules):
-        assert utils.available_sdks(modules=modules) == ['3', '4']
+        assert utils.available_sdks(modules=modules) == ['4']
 
     @pytest.mark.parametrize(
         ('modules', 'require'), [
-            (['ovirtsdk4'], ['4']), (['ovirtsdk'], ['3']),
-            (['ovirtsdk', 'dummy'], ['3'])
+            (['ovirtsdk4'], ['4']),
         ]
     )
     def test_available_one(self, modules, require):
@@ -43,10 +41,6 @@ class TestUtilsOvirtSDKs(object):
     @pytest.mark.parametrize(
         ('modules', 'version'), [
             (['ovirtsdk4'], '4'),
-            (['ovirtsdk'], '3'),
-            (['ovirtsdk', 'dummy'], '3'),
-            (['ovirtsdk', 'ovirtsdk4'], '3'),
-            ([], '3'),
             ([], '4'),
         ]
     )
@@ -59,7 +53,6 @@ class TestUtilsOvirtSDKs(object):
 
     @pytest.mark.parametrize(
         ('modules', 'version'), [
-            (['ovirtsdk4'], '3'),
             (['ovirtsdk'], '4'),
             (['ovirtsdk', 'dummy'], '4'),
         ]


### PR DESCRIPTION
oVirt SDK v3 is not Python 3 compatible and is no longer supported in
oVirt.  Let's not depend on it.

More SDK v3 cleanup is needed, but it's for followup patches.