### PR TITLE
Switch to Python 3 & el8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ ${SPECFILE}: ${SPECFILE}.in changelog
 	cat ChangeLog >> $@
 
 build:
-	OVIRTLAGO_VERSION=${VERSION} python setup.py build
+	OVIRTLAGO_VERSION=${VERSION} python3 setup.py build
 
 check: check-local
 
@@ -60,7 +60,7 @@ check-local:
 dist: ${TARBALL_DIST_LOCATION}
 
 python-sdist:
-	LAGO_VERSION=${VERSION} python2 setup.py sdist --dist-dir ${DIST_DIR}
+	LAGO_VERSION=${VERSION} python3 setup.py sdist --dist-dir ${DIST_DIR}
 
 add-extra-files-sdist: changelog fullchangelog
 	gunzip ${TARBALL_DIST_LOCATION}
@@ -86,7 +86,7 @@ rpm: dist ${SPECFILE}
 		${SPECFILE}
 
 clean:
-	python2 setup.py clean
+	python3 setup.py clean
 	rm -rf ${DIST_DIR}
 	rm -rf ${RPM_DIR}
 	rm -rf build "$(REPO_LOCAL_REL_PATH)"

--- a/automation/build-artifacts.packages.el7
+++ b/automation/build-artifacts.packages.el7
@@ -1,6 +1,0 @@
-git
-python
-python-dulwich
-python-setuptools
-yum
-yum-utils

--- a/automation/build-artifacts.packages.el8
+++ b/automation/build-artifacts.packages.el8
@@ -1,9 +1,6 @@
-dnf
-dnf-command(builddep)
 git
-make
 python3
 python3-dulwich
 python3-setuptools
-rpm-build
-tar
+dnf
+dnf-utils

--- a/automation/build-artifacts.repos.el7
+++ b/automation/build-artifacts.repos.el7
@@ -1,1 +1,0 @@
-check-patch.repos.el7

--- a/automation/build-artifacts.repos.el8
+++ b/automation/build-artifacts.repos.el8
@@ -1,0 +1,1 @@
+check-patch.repos.el8

--- a/automation/build-artifacts.sh
+++ b/automation/build-artifacts.sh
@@ -3,18 +3,12 @@ readonly BUILDS=$PWD/automation-build
 readonly EXPORTS=$PWD/exported-artifacts
 readonly SPEC="lago-ovirt.spec"
 
-if hash dnf &>/dev/null; then
-    YUM="dnf"
-    BUILDDEP="dnf builddep"
-else
-    YUM="yum"
-    BUILDDEP="yum-builddep"
-fi
-echo "cleaning $YUM metadata"
-$YUM clean metadata
+BUILDDEP="dnf builddep"
+echo "cleaning dnf metadata"
+dnf clean metadata
 
 echo "Installing Lago"
-$YUM install -y lago
+dnf install -y lago
 
 echo "cleaning $BUILDS, $EXPORTS"
 rm -rf "$BUILDS" "$EXPORTS"/*{.rpm,.tar.gz}

--- a/automation/check-merged.packages.el7
+++ b/automation/check-merged.packages.el7
@@ -1,1 +1,0 @@
-check-patch.packages.el7

--- a/automation/check-merged.packages.el8
+++ b/automation/check-merged.packages.el8
@@ -1,0 +1,1 @@
+check-patch.packages.el8

--- a/automation/check-merged.repos.el7
+++ b/automation/check-merged.repos.el7
@@ -1,1 +1,0 @@
-check-patch.repos.el7

--- a/automation/check-merged.repos.el8
+++ b/automation/check-merged.repos.el8
@@ -1,0 +1,1 @@
+check-patch.repos.el8

--- a/automation/check-patch.packages
+++ b/automation/check-patch.packages
@@ -4,9 +4,9 @@ dnf-command(builddep)
 git
 gcc
 grubby
-python2-devel
-python2-dulwich
-python-pip
+python3-devel
+python3-dulwich
+python3-pip
 libcurl-devel
 libvirt-devel
 openssl-devel

--- a/automation/check-patch.packages.el8
+++ b/automation/check-patch.packages.el8
@@ -1,8 +1,8 @@
 bats
 git
-python2-devel
-python-dulwich
-python-pip
+python3-devel
+python3-dulwich
+python3-pip
 yum
 yum-utils
 libcurl-devel

--- a/automation/check-patch.repos.el8
+++ b/automation/check-patch.repos.el8
@@ -1,3 +1,2 @@
 lago,http://resources.ovirt.org/repos/lago/stable/0.0/rpm/$distro
 ovirt-ci-tools,http://resources.ovirt.org/repos/ci-tools/$distro
-centos-qemu-ev,http://mirror.centos.org/centos/7/virt/x86_64/kvm-common/

--- a/automation/common.sh
+++ b/automation/common.sh
@@ -52,20 +52,14 @@ run_unit_tests() {
 
 
 run_installation_tests() {
-    local yum
     local res=0
     automation/build-artifacts.sh \
     || return $?
     echo "Installing..."
-    if hash dnf &>/dev/null; then
-        yum=dnf
-    else
-        yum=yum
-    fi
     echo "Install Lago from RPM"
-    $yum install -y lago || return $?
+    dnf install -y lago || return $?
     echo "Installing python-lago-ovirt"
-    $yum install -y exported-artifacts/python-lago-ovirt-*.noarch.rpm || \
+    dnf install -y exported-artifacts/python-lago-ovirt-*.noarch.rpm || \
         return $?
     echo "Imports sanity check"
     lago ovirt -h || res=$?

--- a/automation/common.sh
+++ b/automation/common.sh
@@ -56,6 +56,20 @@ run_installation_tests() {
     automation/build-artifacts.sh \
     || return $?
     echo "Installing..."
+    # TODO: Advanced virt shouldn't be added for Fedora
+    echo "Adding Advanced Virt"
+    cat > /etc/yum.repos.d/advanced-virt.repo <<EOF
+[copr-fedorainfracloud.org-sbonazzo-AdvancedVirtualization]
+name=Copr repo for AdvancedVirtualization owned by sbonazzo
+baseurl=https://copr-be.cloud.fedoraproject.org/results/sbonazzo/AdvancedVirtualization/centos-stream-$basearch/
+type=rpm-md
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/sbonazzo/AdvancedVirtualization/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1
+module_hotfixes=1
+EOF
     echo "Install Lago from RPM"
     dnf install -y lago || return $?
     echo "Installing python-lago-ovirt"

--- a/lago-ovirt.spec.in
+++ b/lago-ovirt.spec.in
@@ -43,11 +43,7 @@ Requires: python3-magic
 Requires: python3-nose
 Requires: python3-ovirt-engine-sdk4 >= 3.6.9.1-1
 Requires: repoman >= 2.0.12
-%if 0%{?fedora} || 0%{?rhel} >= 8
 Requires: dnf-utils
-%else
-Requires: yum-utils
-%endif
 Requires: rpm-build
 Requires: xz
 %{?python_provide:%python_provide python3-%{name}}

--- a/lago-ovirt.spec.in
+++ b/lago-ovirt.spec.in
@@ -7,9 +7,9 @@ Group: System Environment/Libraries
 License: GPLv2+
 URL: https://github.com/lago-project/lago-ost-plugin
 Source0: https://resources.ovirt.org/repos/lago/0.0/src/%{name}/%{name}-%{version}.tar.gz
-BuildRequires: python2-devel
+BuildRequires: python3-devel
 Requires: lago >= 0.39
-Requires: python-%{name} = %{version}
+Requires: python3-%{name} = %{version}
 Provides: lago-ost-plugin
 
 %description
@@ -20,10 +20,10 @@ A Lago plugin to create an oVirt testing environment
 %setup -q -n %{name}-%{version}
 
 %build
-OVIRTLAGO_VERSION=%{version} %{py2_build}
+OVIRTLAGO_VERSION=%{version} %{py3_build}
 
 %install
-OVIRTLAGO_VERSION=%{version} %{py2_install}
+OVIRTLAGO_VERSION=%{version} %{py3_install}
 
 install -d %{buildroot}/var/lib/lago/reposync
 install -d -m 755 %{buildroot}%{_sysconfdir}/firewalld/services
@@ -32,16 +32,16 @@ install -p -D -m 644 etc/firewalld/services/* %{buildroot}%{_sysconfdir}/firewal
 
 %files -n %{name}
 
-###################### python-lago-ovirt package
-%package -n python-%{name}
+###################### python3-lago-ovirt package
+%package -n python3-%{name}
 Summary: Library for ovirt specific facitilies
 BuildArch: noarch
-BuildRequires: python2-devel
-Requires: python
-Requires: python-lago >= 0.39
-Requires: python-magic
-Requires: python-nose
-Requires: ovirt-engine-sdk-python >= 3.6.9.1-1
+BuildRequires: python3-devel
+Requires: python3
+Requires: python3-lago >= 0.39
+Requires: python3-magic
+Requires: python3-nose
+Requires: python3-ovirt-engine-sdk4 >= 3.6.9.1-1
 Requires: repoman >= 2.0.12
 %if 0%{?fedora} || 0%{?rhel} >= 8
 Requires: dnf-utils
@@ -50,20 +50,21 @@ Requires: yum-utils
 %endif
 Requires: rpm-build
 Requires: xz
-%{?python_provide:%python_provide python2-%{name}}
-%{?python_provide:%python_provide python2-lago-ost-plugin}
+%{?python_provide:%python_provide python3-%{name}}
+%{?python_provide:%python_provide python3-lago-ost-plugin}
 
-%description -n python-%{name}
+%description -n python3-%{name}
 
-%files -n python-%{name}
-%{python2_sitelib}/ovirtlago/*.py*
-%{python2_sitelib}/ovirtlago/data/*.yaml
-%{python2_sitelib}/lago_ovirt-%{version}-py*.egg-info
+%files -n python3-%{name}
+%{python3_sitelib}/ovirtlago/*.py*
+%{python3_sitelib}/ovirtlago/__pycache__/*.py*
+%{python3_sitelib}/ovirtlago/data/*.yaml
+%{python3_sitelib}/lago_ovirt-%{version}-py*.egg-info
 
 %config(noreplace) %{_sysconfdir}/firewalld/services/*
 %dir %attr(2775, root, lago) /var/lib/lago/reposync/
 
-%post -n python-%{name}
+%post -n python3-%{name}
 if firewall-cmd --state &>/dev/null; then
     # don't touch if ovirtlago service is already enabled
     if ! firewall-cmd --query-service=ovirtlago --zone=public -q; then
@@ -74,7 +75,7 @@ if firewall-cmd --state &>/dev/null; then
 fi
 
 
-%preun  -n python-%{name}
+%preun  -n python3-%{name}
 if [[ "$1" == "0" ]]; then
     # "0" indicates uninstallation
     # "1" indicates upgrade - and then we do nothing

--- a/ovirtlago/cmd.py
+++ b/ovirtlago/cmd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
 # Copyright 2014 Red Hat, Inc.
 #

--- a/ovirtlago/reposetup.py
+++ b/ovirtlago/reposetup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright 2016 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/ovirtlago/server.py
+++ b/ovirtlago/server.py
@@ -22,8 +22,8 @@ import errno
 import logging
 import os
 import threading
-from SimpleHTTPServer import SimpleHTTPRequestHandler
-from SocketServer import ThreadingTCPServer
+from http.server import SimpleHTTPRequestHandler
+from socketserver import ThreadingTCPServer
 import sys
 import traceback
 

--- a/scripts/check_style.sh
+++ b/scripts/check_style.sh
@@ -30,7 +30,7 @@ if [[ -n "${yapf_diff// }" ]]; then
     Yapf failed, make sure to run:
         yapf --style .style.yapf --in-place --recursive .
 
-    If you want to make it run faster, on python2 ensure you have 'futures'
+    If you want to make it run faster, on python3 ensure you have 'futures'
     installed from pip and run:
         yapf --style .style.yapf --in-place --parallel --recursive .
 

--- a/scripts/version_manager.py
+++ b/scripts/version_manager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 import argparse
 import copy
 import datetime

--- a/test-requires.txt
+++ b/test-requires.txt
@@ -7,7 +7,6 @@ yapf==0.20
 pytest-cov
 flake8
 dulwich
-enum
 lago
 mock
 ovirt-engine-sdk-python

--- a/tests/functional/fixtures/ovirt.runtest/001_basic_errored_test.py
+++ b/tests/functional/fixtures/ovirt.runtest/001_basic_errored_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 
 def test_error():

--- a/tests/functional/fixtures/ovirt.runtest/001_basic_failed_test.py
+++ b/tests/functional/fixtures/ovirt.runtest/001_basic_failed_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 
 def test_fail():

--- a/tests/functional/fixtures/ovirt.runtest/001_basic_test.py
+++ b/tests/functional/fixtures/ovirt.runtest/001_basic_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 
 def test_pass():

--- a/tests/functional/fixtures/ovirt.runtest/002_testlib.py
+++ b/tests/functional/fixtures/ovirt.runtest/002_testlib.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 import nose.tools as nt
 from ovirtlago import testlib
 


### PR DESCRIPTION
Once all the preparatory pull requests are merged, we can switch to Python 3 + el8. There is no need to retain Python 3 compatibility, changes to lago-ost-plugin are rare and we can keep using the last released Python 2 lago-ost-plugin version in Python2 + el7 environments.