### PR TITLE
testlib: Break circular dependency

### DIFF
--- a/ovirtlago/testlib.py
+++ b/ovirtlago/testlib.py
@@ -29,7 +29,6 @@ from nose.plugins.skip import SkipTest
 from lago import (utils, log_utils)
 from lago.plugins.vm import (ExtractPathError, ExtractPathNoPathError)
 
-import ovirtlago
 
 LOGGER = logging.getLogger(__name__)
 SHORT_TIMEOUT = 3 * 60
@@ -39,6 +38,9 @@ _test_prefix = None
 
 
 def get_test_prefix():
+    # Needs to be here to break circular dependency
+    import ovirtlago.prefix
+
     global _test_prefix
     if _test_prefix is None:
         cur_workdir_path = os.environ.get('LAGO_WORKDIR_PATH', os.curdir)


### PR DESCRIPTION
We have a circular dependency in the project - 'testlib' needs
the 'prefix' module and 'prefix' module imports 'testlib'.

This patch breaks the chain by importing the 'prefix' module
as late as possible.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>